### PR TITLE
CompilerFolder doesn't transfer installed Apps to NuGet resolution (#…

### DIFF
--- a/AppHandling/Compile-AppInNavContainer.ps1
+++ b/AppHandling/Compile-AppInNavContainer.ps1
@@ -482,8 +482,7 @@ try {
                         }
                     }
                     if ($throw) {
-                        Write-Host "ERROR $($_.Exception.Message)"
-                        throw (GetExtendedErrorMessage $_)
+                        throw "Error downloading symbols for $symbolsName. Error was: $($_.Exception.Message)"
                     }
                 }
                 if (Test-Path -Path $symbolsFile) {

--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -474,7 +474,7 @@ function UpdateLaunchJson {
 
 }
 
-function GetInstalledAppIds {
+function GetInstalledApps {
     Param(
         [bool] $useCompilerFolder,
         [string] $packagesFolder,
@@ -491,8 +491,10 @@ function GetInstalledAppIds {
         $installedApps = Get-ChildItem -Path (Join-Path $packagesFolder '*.app') | ForEach-Object {
             $appJson = Get-AppJsonFromAppFile -appFile $_.FullName
             return @{
-                "appId"                 = $appJson.id
-                "name"                  = $appJson.name
+                "AppId"                 = $appJson.id
+                "Name"                  = $appJson.name
+                "Publisher"             = $appJson.publisher
+                "Version"               = $appJson.version
             }
         }
     }
@@ -506,7 +508,7 @@ function GetInstalledAppIds {
     Write-GroupStart -Message "Installed Apps"
     $installedApps | ForEach-Object {
         Write-Host "- $($_.AppId):$($_.Name)"
-        "$($_.AppId)"
+        return @{ "Id" = "$($_.AppId)"; "Name" = "$($_.Name)"; "Publisher" = "$($_.Publisher)"; "Version" = "$($_.Version)" }
     }
     Write-GroupEnd
 }
@@ -1455,8 +1457,8 @@ Write-GroupEnd
 }
 
 if ($InstallMissingDependencies) {
-$installedAppIds = @(GetInstalledAppIds -useCompilerFolder $useCompilerFolder -filesOnly $filesOnly -packagesFolder $packagesFolder)
-$missingAppDependencies = @($missingAppDependencies | Where-Object { $installedAppIds -notcontains $_ })
+$installedApps = @(GetInstalledApps -useCompilerFolder $useCompilerFolder -filesOnly $filesOnly -packagesFolder $packagesFolder)
+$missingAppDependencies = @($missingAppDependencies | Where-Object { $installedApps.Id -notcontains $_ })
 if ($missingAppDependencies) {
 Write-GroupStart -Message "Installing app dependencies"
 Write-Host -ForegroundColor Yellow @'
@@ -1482,6 +1484,8 @@ Measure-Command {
     $Parameters = @{
         "missingDependencies" = @($unknownAppDependencies | Where-Object { $missingAppDependencies -contains "$_".Split(':')[0] })
         "appSymbolsFolder" = $appSymbolsFolder
+        "installedApps" = $installedApps
+        "installedCountry" = $artifactUrl.Substring($artifactUrl.LastIndexOf('/')+1)
     }
     if (!($useCompilerFolder -or $filesOnly)) {
         $Parameters += @{
@@ -1498,7 +1502,7 @@ Measure-Command {
     if ($useCompilerFolder) {
         Write-Host "check $appSymbolsFolder"
         Get-ChildItem -Path $appSymbolsFolder | ForEach-Object {
-            Write-Host "Move $($_.Name)"
+            Write-Host "Move $($_.Name) to $packagesFolder"
             Move-Item -Path $_.FullName -Destination $packagesFolder -Force
             $appsBeforeApps += @(Join-Path $packagesFolder $_.Name)
         }
@@ -1628,8 +1632,8 @@ Write-GroupEnd
 }
 
 if ((($testCountry) -or !($appFolders -or $testFolders -or $bcptTestFolders)) -and ($InstallMissingDependencies)) {
-$installedAppIds = @(GetInstalledAppIds -useCompilerFolder $useCompilerFolder -filesOnly $filesOnly -compilerFolder (GetCompilerFolder) -packagesFolder $packagesFolder)
-$missingTestAppDependencies = @($missingTestAppDependencies | Where-Object { $installedAppIds -notcontains $_ })
+$installedApps = @(GetInstalledApps -useCompilerFolder $useCompilerFolder -filesOnly $filesOnly -compilerFolder (GetCompilerFolder) -packagesFolder $packagesFolder)
+$missingTestAppDependencies = @($missingTestAppDependencies | Where-Object { $installedApps.Id -notcontains $_ })
 if ($missingTestAppDependencies) {
 Write-GroupStart -Message "Installing test app dependencies"
 Write-Host -ForegroundColor Yellow @'
@@ -1655,6 +1659,8 @@ Measure-Command {
     $Parameters = @{
         "missingDependencies" = @($unknownTestAppDependencies | Where-Object { $missingTestAppDependencies -contains "$_".Split(':')[0] })
         "appSymbolsFolder" = $appSymbolsFolder
+        "installedApps" = $installedApps
+        "installedCountry" = $artifactUrl.Substring($artifactUrl.LastIndexOf('/')+1)
     }
     if (!($useCompilerFolder -or $filesOnly)) {
         $Parameters += @{
@@ -1834,8 +1840,8 @@ Measure-Command {
 Write-GroupEnd
 
 if ($InstallMissingDependencies) {
-$installedAppIds = @(GetInstalledAppIds -useCompilerFolder $useCompilerFolder -filesOnly $filesOnly -packagesFolder $packagesFolder)
-$missingTestAppDependencies = @($missingTestAppDependencies | Where-Object { $installedAppIds -notcontains $_ })
+$installedApps = @(GetInstalledApps -useCompilerFolder $useCompilerFolder -filesOnly $filesOnly -packagesFolder $packagesFolder)
+$missingTestAppDependencies = @($missingTestAppDependencies | Where-Object { $installedApps.Id -notcontains $_ })
 if ($missingTestAppDependencies) {
 Write-GroupStart -Message "Installing test app dependencies"
 Write-Host -ForegroundColor Yellow @'
@@ -2466,13 +2472,13 @@ if ($testCountry) {
     Write-Host -ForegroundColor Yellow "Publishing apps for additional country $testCountry"
 }
 
-$installedApps = @()
+$alreadyInstalledApps = @()
 if (!($bcAuthContext)) {
     $Parameters = @{
         "containerName" = (GetBuildContainer)
         "tenant" = $tenant
     }
-    $installedApps = Invoke-Command -ScriptBlock $GetBcContainerAppInfo -ArgumentList $Parameters
+    $alreadyInstalledApps = Invoke-Command -ScriptBlock $GetBcContainerAppInfo -ArgumentList $Parameters
 }
 
 $upgradedApps = @()
@@ -2485,7 +2491,7 @@ $apps | ForEach-Object {
         $appJson = [System.IO.File]::ReadAllLines($appJsonFile) | ConvertFrom-Json
         $upgradedApps += @($appJson.Id.ToLowerInvariant())
 
-        if ($installedApps | Where-Object { "$($_.AppId)" -eq $appJson.Id }) {
+        if ($alreadyInstalledApps | Where-Object { "$($_.AppId)" -eq $appJson.Id }) {
             $installedApp = $true
         }
     }
@@ -2685,11 +2691,11 @@ $testFolders | ForEach-Object {
     }
 }
 
-$installedAppIds = @(GetInstalledAppIds -useCompilerFolder $useCompilerFolder -filesOnly $filesOnly -compilerFolder (GetCompilerFolder) -packagesFolder $packagesFolder)
+$installedApps = @(GetInstalledApps -useCompilerFolder $useCompilerFolder -filesOnly $filesOnly -compilerFolder (GetCompilerFolder) -packagesFolder $packagesFolder)
 $testAppIds.Keys | ForEach-Object {
     $disabledTests = @()
     $id = $_
-    if ($installedAppIds -notcontains $id) {
+    if ($installedApps.Id -notcontains $id) {
         throw "App with $id is not installed, cannot run tests"
     }
     $folder = $testAppIds."$id"

--- a/NuGet/Download-BcNuGetPackageToFolder.ps1
+++ b/NuGet/Download-BcNuGetPackageToFolder.ps1
@@ -245,6 +245,10 @@ try {
                         $downloadIt = ($downloadDependencies -ne 'none')
                     }
                 }
+                # When downloading symbols, country will be symbols if no specific country is specified
+                if ($dependencyCountry -eq 'symbols') {
+                    $dependencyCountry = ''
+                }
                 if ($installedCountry -and $dependencyCountry -and ($installedCountry -ne $dependencyCountry)) {
                     # The NuGet package found isn't compatible with the installed application
                     Write-Host "WARNING: NuGet package $packageId (version $packageVersion) requires $dependencyCountry application. You have $installedCountry application installed"

--- a/NuGet/Publish-BcNuGetPackageToContainer.ps1
+++ b/NuGet/Publish-BcNuGetPackageToContainer.ps1
@@ -90,8 +90,11 @@ Function Publish-BcNuGetPackageToContainer {
             }
             Publish-BcContainerApp -containerName $containerName -bcAuthContext $bcAuthContext -environment $environment -tenant $tenant -appFile $appFiles -sync -install -upgrade -checkAlreadyInstalled -skipVerification -copyInstalledAppsToFolder $copyInstalledAppsToFolder
         }
-        else {
+        elseif ($ErrorActionPreference -eq 'Stop') {
             throw "No apps to publish"
+        }
+        else {
+            Write-Host "No apps to publish"
         }
     }
     finally {

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,5 +1,7 @@
 6.0.35
 AL-Go issue 1288 Library apps are not installed if only referenced from test apps
+AL-Go issue 1330 CompilerFolder doesn't transfer installed Apps to NuGet resolution
+AL-Go issue 1268 Do not throw an un-understandable error during nuGet download
 
 6.0.34
 Compare files before giving a warning about apps with the same name in Run-AlPipeline


### PR DESCRIPTION
…3832)

This PR is the BcContainerHelper part of making sure that the installed apps, the platform and the country are transferred to NuGet resolution when locating apps for downloading - making sure that you don't download a package with dependencies to BC which is newer than what you are building for.

It is a requirement for https://github.com/microsoft/AL-Go/pull/1450

---------